### PR TITLE
Use compiler to check code format

### DIFF
--- a/src/crystal_analyzer/format_checker.cr
+++ b/src/crystal_analyzer/format_checker.cr
@@ -1,9 +1,13 @@
+require "compiler/crystal/tools/formatter"
+
 module CrystalAnalyzer
   module FormatChecker
     extend self
 
     def valid_format?(filepath : String)
-      system %(crystal tool format --check #{filepath})
+      source = File.read(filepath)
+      result = Crystal.format(source, filename: filepath)
+      result == source
     end
   end
 end


### PR DESCRIPTION
Crystal allows you to include parts of the compiler from the stdlib, so to check the format we can utilize the formatter directly rather than executing a sub shell.  This would also allow us to deploy the binary without Crystal being installed I believe.

Longer term if more analysis is implemented we would probably want to utilize the compiler's lexer/ parser as well.
